### PR TITLE
feat: <names>: basic implementation. closes #117

### DIFF
--- a/packages/csl-features-extras/features/names.feature
+++ b/packages/csl-features-extras/features/names.feature
@@ -1,0 +1,45 @@
+Feature: Names
+
+Scenario: Renders only one name variable
+  Given the following citation style
+    """
+    <style class="note" version="1.0" xmlns="http://purl.org/net/xbiblio/csl">
+      <info>
+        <id/>
+        <title/>
+        <updated>2008-10-29T21:01:24+00:00</updated>
+      </info>
+      <citation>
+        <layout>
+          <names variable="author"/>
+        </layout>
+      </citation>
+    </style>
+    """
+  And the following data
+    """
+    [
+      {
+        "author": [
+          {
+            "given": "Jean",
+            "family": "Fontaine",
+            "dropping-particle": "de",
+            "non-dropping-particle": "La",
+            "suffix": "I"
+          },
+          {
+            "given": "Jean",
+            "family": "Fontaine",
+            "dropping-particle": "de",
+            "non-dropping-particle": "La",
+            "suffix": "II"
+          }
+        ]
+      }
+    ]
+    """
+  Then the following result is expected
+    """
+    Jean de La Fontaine I, Jean de La Fontaine II
+    """

--- a/packages/csl-generator/lib/module.xsl
+++ b/packages/csl-generator/lib/module.xsl
@@ -4,7 +4,8 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:csl="http://purl.org/net/xbiblio/csl"
   xmlns:str="http://exslt.org/strings"
-  extension-element-prefixes="str">
+  xmlns:exsl="http://exslt.org/common"
+  extension-element-prefixes="str exsl">
 
   <xsl:import href="../node_modules/@customcommander/csl-locales/lib/xml2json.xsl"/>
 
@@ -51,6 +52,146 @@
 
   <xsl:template match="csl:*" mode="param-children">
     [<xsl:for-each select="csl:*">
+      <xsl:apply-templates select="." mode="function-call"/>
+      <xsl:if test="position() != last()">,</xsl:if>
+    </xsl:for-each>]
+  </xsl:template>
+
+  <!--
+  Why do we need a special `param-children` template for `<names>`?
+
+  The following snippets of CSL are equivalent:
+
+  Snippet 1:
+
+    <names variable="author">
+      <name/>
+    </names>
+
+  Snippet 2:
+
+    <names variable="author"/>
+
+  Both will render all the names in the `author` variable delimited with
+  the following string `, `.
+
+  However the extraction of the names in the `author` variable, the rendering of names
+  and the definition of the name delimiter is the responsibility of the `<name>` element.
+
+  Since the `<name>` instance in the first snippet relies on default values and behaviour,
+  it can be rewritten as shown in the second snippet.
+
+  However in our implementation model where each CSL element has its own module with no
+  knowledge of its ancestors or children, and where the code generator (i.e. this stylesheet)
+  will only generate code from CSL elements that it can "see", the second snippet will produce
+  code that won't be able to render anything.
+
+  Therefore we must be able to detect snippet 2 and rewrite it into snippet 1.
+  This template rewrites an abbreviated `<names>` tree into one that exposes
+  its children explicitly to the code generator.
+
+  So this `<names>` tree:
+
+    <names variable="author"/>
+
+  Is rewritten to:
+
+    <names variable="author">
+      <name/>
+    </names>
+
+  There is also another factor to consider.
+  The `<names>` element also has an implicit order of its children:
+
+  The following snippets are equivalent:
+
+  Snippet 3:
+
+    <names variable="author">
+      <name/>
+      <label prefix=" (" suffix=")"/>
+    </names>
+
+  Snippet 4:
+
+    <names variable="author">
+      <label prefix=" (" suffix=")"/>
+    </names>
+
+  Both will render "Doe, Smith (authors)". Since `<name/>` in snippet 3 relies on
+  default values and behaviours, it can be omitted (as shown in snippet 4). However
+  in both cases, the list of names is shown before its label.
+
+  If the children in `<names>` are not explicitly exposed to the code generator,
+  the generated code for snippet 4 wouldn't be able to render a list of names.
+
+  Therefore when parsing the CSL tree for `<names>` this template must rewrite
+  snippet 4 into snippet 3.
+
+  *****************************************************************************
+
+  What is this `<name-list>` that isn't documented in the CSL specification?
+
+  The `<name-list>` element is a convenience method for encapsulating
+  and delimiting lists of names from `<name>` elements when `<names>`
+  has multiple name variables. (e.g. `<names variable="author editor">`.)
+
+  The purpose of `<name-list>` is to capture the output of the entire `<names>` tree
+  for each name variable. So that it's easier to separate two lists of names with
+  a delimiter set on `<names>`.
+
+  The following `<names>` tree:
+
+  <names variable="author editor" delimiter="; ">
+    <label/>
+  </names>
+
+  Will be rewritten (by this template) into:
+
+  <names variable="author editor" delimiter="; ">
+    <name-list variable="author">
+      <name variable="author"/>
+      <label/>
+    </name-list>
+    <name-list variable="editor">
+      <name variable="editor"/>
+      <label/>
+    </name-list>
+  </names>
+
+  Both ultimately producing the same output,
+  e.g. "Doe, Smith (authors); Brown, Baggins (editors)"
+
+  Note:
+
+  The `variable` attribute is passed to different elements
+  (sometimes against the CSL specification) in order to tell
+  each rendering function on which data to operate.
+
+  Remember that each CSL element is implemented into its own,
+  isolated module with no knowledge of its context or its ancestors or children.
+
+  -->
+  <xsl:template match="csl:names" mode="param-children">
+
+    <xsl:variable name="original-node" select="."/>
+
+    <xsl:variable name="reprocessed">
+      <xsl:for-each select="str:tokenize($original-node/@variable)">
+        <xsl:element name="csl:name-list">
+          <xsl:attribute name="variable"><xsl:value-of select="."/></xsl:attribute>
+          <!-- Recreating a <name> element with any existing attributes (plus some others) -->
+          <xsl:element name="csl:name">
+            <xsl:attribute name="variable"><xsl:value-of select="."/></xsl:attribute>
+            <xsl:for-each select="$original-node/csl:name/@*">
+              <xsl:attribute name="{name()}"><xsl:value-of select="."/></xsl:attribute>
+            </xsl:for-each>
+          </xsl:element>
+        </xsl:element>
+      </xsl:for-each>
+    </xsl:variable>
+
+    [<xsl:for-each select="exsl:node-set($reprocessed)/csl:name-list">
       <xsl:apply-templates select="." mode="function-call"/>
       <xsl:if test="position() != last()">,</xsl:if>
     </xsl:for-each>]

--- a/packages/csl-lib/index.js
+++ b/packages/csl-lib/index.js
@@ -8,6 +8,9 @@ module.exports = {
   'if': require('./lib/if.js'),
   'label': require('./lib/label.js'),
   'layout': require('./lib/layout.js'),
+  'name-list': require('./lib/name-list'),
+  'name': require('./lib/name'),
+  'names': require('./lib/names.js'),
   'number': require('./lib/number.js'),
   'text': require('./lib/text.js'),
   // some utilities

--- a/packages/csl-lib/lib/name-list.js
+++ b/packages/csl-lib/lib/name-list.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright (c) 2019 Julien Gonzalez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const {
+  applyTo,
+  curry,
+  map
+} = require('ramda');
+
+const output = require('./output');
+
+/**
+ * @function
+ * @param {Locale[]} locales
+ * @param {object} macros
+ * @param {NameListAttrs} attrs
+ * @param {function[]} children
+ * @param {object} ref
+ * @return {Output}
+ */
+module.exports = curry((locales, macros, attrs, children, ref) =>
+  output({name: attrs.variable}, 'name-list',
+    map(applyTo(ref), children)));

--- a/packages/csl-lib/lib/name.js
+++ b/packages/csl-lib/lib/name.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright (c) 2019 Julien Gonzalez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const {
+  compose,
+  converge,
+  curry,
+  defaultTo,
+  lensProp,
+  map,
+  over,
+  pipe,
+  propOr,
+} = require('ramda');
+
+const output = require('./output');
+const {formatLatinLongName} = require('./utils/name');
+const delimAttr = require('./attributes/delimiter');
+
+const defaultDelimiter = over(lensProp('delimiter'), defaultTo(', '));
+
+const attributes =
+  converge(pipe, [
+    compose(delimAttr, defaultDelimiter)]);
+
+/**
+ * @function
+ * @param {Locale[]} locales
+ * @param {object} macros
+ * @param {NameAttrs} attrs
+ * @param {function[]} children
+ * @param {object} ref
+ * @return {Output}
+ */
+module.exports = curry((locales, macros, attrs, children, ref) =>
+  pipe(
+    propOr([], attrs.variable),
+    map(formatLatinLongName),
+    output({name: attrs.variable}, 'name'),
+    attributes(attrs))
+      (ref));

--- a/packages/csl-lib/lib/names.js
+++ b/packages/csl-lib/lib/names.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2019 Julien Gonzalez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const {applyTo, curry, map} = require('ramda');
+const output = require('./output');
+
+/**
+ * @function
+ * @param {Locale[]} locales
+ * @param {object} macros
+ * @param {NamesAttrs} attrs
+ * @param {function[]} children
+ * @param {object} ref
+ * @return {Output}
+ */
+module.exports = curry((locales, macros, attrs, children, ref) =>
+  output({}, 'names', map(applyTo(ref), children)));

--- a/packages/csl-lib/lib/types/attributes.js
+++ b/packages/csl-lib/lib/types/attributes.js
@@ -1,0 +1,22 @@
+/**
+ * Attributes for <name>
+ * @see {@link https://docs.citationstyles.org/en/master/specification.html#name}
+ * @typedef {object} NameAttrs
+ * @property {enums.personType} `variable` - The name variable to render
+ * @property {?string} `delimiter` - The delimiter to separate the names in a name variable. Default is ", ".
+ */
+
+/**
+ * Attributes for <name-list>
+ * (Notice: this element isn't part of the CSL specification and only exist as a helper to the citegen project)
+ * @typedef {object} NameListAttrs
+ * @property {enums.personType} `variable` - The name variable to render
+ */
+
+/**
+ * Attributes for <names>
+ * @see {@link https://docs.citationstyles.org/en/master/specification.html#names}
+ * @typedef {object} NamesAttrs
+ * @property {enums.personType} `variable`
+ * @property {?string} `delimiter`
+ */

--- a/packages/csl-lib/lib/types/enums.js
+++ b/packages/csl-lib/lib/types/enums.js
@@ -1,0 +1,41 @@
+const enums = {};
+
+/** @enum {string} */
+enums.genderType = {
+  'feminine': 'feminine',
+  'masculine': 'masculine',
+  'neuter': 'neuter'
+};
+
+/**
+ * @enum {string}
+ * @see {@link https://docs.citationstyles.org/en/master/specification.html#name-variables}
+ */
+enums.personType = {
+  /** author */
+  'author': 'author',
+  /** editor of the collection holding the item (e.g. the series editor for a book) */
+  'collection-editor': 'collection-editor',
+  /** composer (e.g. of a musical score) */
+  'composer': 'composer',
+  /** author of the container holding the item (e.g. the book author for a book chapter) */
+  'container-author': 'container-author',
+  /** director (e.g. of a film) */
+  'director': 'director',
+  /** editor */
+  'editor': 'editor',
+  /** managing editor (“Directeur de la Publication” in French) */
+  'editorial-director': 'editorial-director',
+  /** illustrator (e.g. of a children’s book) */
+  'illustrator': 'illustrator',
+  /** interviewer (e.g. of an interview) */
+  'interviewer': 'interviewer',
+  /** ? */
+  'original-author': 'original-author',
+  /** recipient (e.g. of a letter) */
+  'recipient': 'recipient',
+  /** author of the item reviewed by the current item */
+  'reviewed-author': 'reviewed-author',
+  /** translator */
+  'translator': 'translator',
+};

--- a/packages/csl-lib/lib/types/locale.js
+++ b/packages/csl-lib/lib/types/locale.js
@@ -1,0 +1,30 @@
+/**
+ * @typedef {object} StyleOptions
+ * @property {string} `limit-day-ordinals-to-day-1`
+ * @property {string} `punctuation-in-quote`
+ */
+
+/**
+ * @typedef {object} DatePart
+ * @property {string} `form`
+ * @property {string} `name`
+ * @property {?string} `prefix`
+ * @property {?string} `suffix`
+ */
+
+/**
+ * @typedef {object} Term
+ * @property {string} `name`
+ * @property {string} `form`
+ * @property {enums.genderType} `gender`
+ * @property {enums.genderType} `gender-form`
+ * @property {string[]} `value`
+ */
+
+ /**
+ * @typedef {object} Locale
+ * @property {StyleOptions} `style_options`
+ * @property {DatePart[]} `date_text`
+ * @property {DatePart[]} `date_numeric`
+ * @property {Term[]} `terms`
+ */

--- a/packages/csl-lib/lib/utils/name.js
+++ b/packages/csl-lib/lib/utils/name.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright (c) 2019 Julien Gonzalez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const {
+  compose,
+  converge,
+  isEmpty,
+  join,
+  propOr,
+  reject,
+  unapply
+} = require('ramda');
+
+/**
+ * @example
+ * @function
+ * @param {string[]} nameParts
+ * @return {string}
+ */
+const joinNameParts = compose(join(' '), reject(isEmpty));
+
+/**
+ * @function
+ * @param {NameVariable} name
+ * @return {string}
+ */
+const formatLatinLongName =
+  converge(unapply(joinNameParts), [
+    propOr('', 'given'),
+    propOr('', 'dropping-particle'),
+    propOr('', 'non-dropping-particle'),
+    propOr('', 'family'),
+    propOr('', 'suffix')]);
+
+module.exports = {
+  formatLatinLongName
+};

--- a/packages/csl-lib/lib/utils/name.test.js
+++ b/packages/csl-lib/lib/utils/name.test.js
@@ -1,0 +1,11 @@
+const tap = require('tap');
+const sut = require('./name');
+
+tap.equal(
+  sut.formatLatinLongName({
+    'given': 'Jean',
+    'dropping-particle': 'de',
+    'non-dropping-particle': 'La',
+    'family': 'Fontaine',
+    'suffix': 'III'}),
+  'Jean de La Fontaine III');

--- a/packages/csl-lib/samples/names.txt
+++ b/packages/csl-lib/samples/names.txt
@@ -1,0 +1,326 @@
+<!--<names variable="reviewed-author" prefix="recension d’un ouvrage de "><name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with=". "/></names><text variable="event" quotes="true" prefix="actes du colloque "/> : ces variables risqueraient d'être redondantes avec des informations déjà présentes dans le champ Extra-->
+<macro name="conferenceName"><names variable="event" font-style="italic"><name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"></name></names></macro>
+<macro name="editor"><choose><if type="chapter" match="none"></if></choose><names variable="editor"><name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"><name-part name="family" font-variant="small-caps"/></name><label form="short" prefix="&#160;(" suffix=".)"/></names></macro>
+<names delimiter=", " prefix="In: " variable="editor">
+<names delimiter=", " variable="container-author">
+<names delimiter=", " variable="editor translator">
+<names delimiter=", " variable="editor" suffix=",">
+<names delimiter=", " variable="editor">
+<names delimiter=", " variable="interviewer">
+<names delimiter=", " variable="recipient">
+<names delimiter=", " variable="reviewed-author">
+<names delimiter=", " variable="translator" suffix=",">
+<names delimiter=". " variable="director">
+<names delimiter=". " variable="editor translator">
+<names font-variant="small-caps" variable="collection-editor">
+<names variable=" " delimiter=" ; ">
+<names variable="author director"/>
+<names variable="author editor">
+<names variable="author interviewer">
+<names variable="author" delimiter=" ">
+<names variable="author" delimiter=" ; ">
+<names variable="author" delimiter=", ">
+<names variable="author" delimiter="," prefix=" / " suffix=",">
+<names variable="author" delimiter=",">
+<names variable="author" delimiter="/">
+<names variable="author" delimiter="; " suffix=" ">
+<names variable="author" delimiter="; ">
+<names variable="author" font-style="italic" delimiter=" ">
+<names variable="author" font-style="italic" delimiter="/">
+<names variable="author" font-style="italic">
+<names variable="author" font-style="normal">
+<names variable="author" font-variant="normal" delimiter=" ; ">
+<names variable="author" font-variant="normal" delimiter=", ">
+<names variable="author" font-variant="normal" delimiter=",">
+<names variable="author" font-variant="normal" delimiter="."/>
+<names variable="author" font-variant="normal" font-weight="normal" vertical-align="baseline">
+<names variable="author" font-variant="normal" font-weight="normal">
+<names variable="author" font-variant="normal" suffix=", ">
+<names variable="author" font-variant="normal" suffix=".">
+<names variable="author" font-variant="normal" vertical-align="baseline" suffix=". ">
+<names variable="author" font-variant="normal" vertical-align="baseline">
+<names variable="author" font-variant="normal">
+<names variable="author" font-variant="small-caps" suffix=".">
+<names variable="author" font-variant="small-caps">
+<names variable="author" font-weight="bold" delimiter=",">
+<names variable="author" font-weight="bold" suffix=". ">
+<names variable="author" font-weight="bold">
+<names variable="author" font-weight="normal">
+<names variable="author" prefix="           |authors=">
+<names variable="author" prefix=" ">
+<names variable="author" prefix="(" suffix=" ">
+<names variable="author" prefix="Directed by " suffix="."/>
+<names variable="author" prefix="Directed by "/>
+<names variable="author" prefix="Directed by ">
+<names variable="author" prefix="Interview with ">
+<names variable="author" prefix="See ">
+<names variable="author" prefix="invs.: "/>
+<names variable="author" suffix=" ">
+<names variable="author" suffix=" :">
+<names variable="author" suffix="">
+<names variable="author" suffix=", "/>
+<names variable="author" suffix=", ">
+<names variable="author" suffix="," font-variant="small-caps">
+<names variable="author" suffix=",">
+<names variable="author" suffix=".  ">
+<names variable="author" suffix=". ">
+<names variable="author" suffix=". - ">
+<names variable="author" suffix=".">
+<names variable="author" suffix="/">
+<names variable="author" suffix=": ">
+<names variable="author" suffix=":">
+<names variable="author" suffix="，">
+<names variable="author" vertical-align="baseline">
+<names variable="author"/>
+<names variable="author">
+<names variable="collection-editor composer container-author director editor editorial-director illustrator reviewed-author original-author translator"/>
+<names variable="collection-editor" delimiter=" ; ">
+<names variable="collection-editor" delimiter=", ">
+<names variable="collection-editor" delimiter="; ">
+<names variable="collection-editor" font-variant="small-caps">
+<names variable="collection-editor" prefix="dirigée par ">
+<names variable="collection-editor" prefix="ed. ser. ">
+<names variable="collection-editor" suffix=" (ed. ser.)">
+<names variable="collection-editor" suffix=" (ed. ser.).">
+<names variable="collection-editor" suffix=". ">
+<names variable="collection-editor" suffix=".">
+<names variable="collection-editor"/>
+<names variable="collection-editor">
+<names variable="composer editor">
+<names variable="composer" delimiter=" ; ">
+<names variable="composer"/>
+<names variable="composer">
+<names variable="container-author editor" delimiter=", ">
+<names variable="container-author editor" font-variant="normal" delimiter=", ">
+<names variable="container-author editor">
+<names variable="container-author reviewed-author">
+<names variable="container-author translator" delimiter="," suffix=",">
+<names variable="container-author" delimiter=" ; ">
+<names variable="container-author" delimiter=", " suffix=", ">
+<names variable="container-author" delimiter=", ">
+<names variable="container-author" font-variant="normal" delimiter=", ">
+<names variable="container-author" prefix=" ">
+<names variable="container-author" prefix="by "/>
+<names variable="container-author" suffix=" ">
+<names variable="container-author" suffix=", ">
+<names variable="container-author" suffix=".">
+<names variable="container-author" suffix=": ">
+<names variable="container-author"/>
+<names variable="container-author">
+<names variable="director" delimiter=", ">
+<names variable="director" delimiter=". ">
+<names variable="director" prefix="R.: ">
+<names variable="director" prefix="R: " suffix=")"/>
+<names variable="director" suffix=", ">
+<names variable="director"/>
+<names variable="director">
+<names variable="editor collection-editor" font-variant="small-caps" suffix="(eds.)"/>
+<names variable="editor collection-editor"/>
+<names variable="editor container-author" delimiter=", " suffix=", ">
+<names variable="editor container-author"/>
+<names variable="editor director" delimiter=". " prefix=", ">
+<names variable="editor translator container-author" delimiter=", " suffix=", ">
+<names variable="editor translator container-author" delimiter=", ">
+<names variable="editor translator container-author" delimiter=". ">
+<names variable="editor translator" delimiter=" ; ">
+<names variable="editor translator" delimiter=", " prefix=" ">
+<names variable="editor translator" delimiter=", " prefix=" (" suffix=")">
+<names variable="editor translator" delimiter=", " prefix=" (" suffix=").">
+<names variable="editor translator" delimiter=", " prefix="(" suffix=")">
+<names variable="editor translator" delimiter=", " prefix=". ">
+<names variable="editor translator" delimiter=", " suffix="  ">
+<names variable="editor translator" delimiter=", " suffix=" ">
+<names variable="editor translator" delimiter=", " suffix=" (dir.)">
+<names variable="editor translator" delimiter=", " suffix=", ">
+<names variable="editor translator" delimiter=", " suffix=",">
+<names variable="editor translator" delimiter=", " suffix=". ">
+<names variable="editor translator" delimiter=", " suffix=".">
+<names variable="editor translator" delimiter=", " suffix=": ">
+<names variable="editor translator" delimiter=", " suffix="; ">
+<names variable="editor translator" delimiter=", ">
+<names variable="editor translator" delimiter="," suffix=" ">
+<names variable="editor translator" delimiter="," suffix=", ">
+<names variable="editor translator" delimiter="," suffix=",">
+<names variable="editor translator" delimiter=",">
+<names variable="editor translator" delimiter=". ">
+<names variable="editor translator" delimiter="/">
+<names variable="editor translator" delimiter="; " prefix="(" suffix=")">
+<names variable="editor translator" delimiter="; " suffix=".">
+<names variable="editor translator" delimiter="; " suffix=": ">
+<names variable="editor translator" delimiter="; ">
+<names variable="editor translator" font-variant="normal" delimiter="; ">
+<names variable="editor translator" font-weight="normal" delimiter=", " prefix=" ">
+<names variable="editor translator" prefix=" " delimiter=", ">
+<names variable="editor translator" prefix=" " suffix="," delimiter=", ">
+<names variable="editor translator" prefix=" ">
+<names variable="editor translator" prefix=" (" delimiter=", " suffix=")">
+<names variable="editor translator" prefix=" (" suffix=")" delimiter=", ">
+<names variable="editor translator" prefix=" (" suffix=")">
+<names variable="editor translator" prefix="(" suffix=")" delimiter=", ">
+<names variable="editor translator" prefix="(" suffix=")">
+<names variable="editor translator" prefix="(" suffix=")." delimiter=", ">
+<names variable="editor translator" prefix="(ed. by " suffix=")" delimiter=", ">
+<names variable="editor translator" suffix=" " delimiter=", ">
+<names variable="editor translator" suffix=", ">
+<names variable="editor translator" suffix=". ">
+<names variable="editor translator"/>
+<names variable="editor translator">
+<names variable="editor" delimiter=" ">
+<names variable="editor" delimiter=" ; ">
+<names variable="editor" delimiter=", " prefix=" " suffix=", ">
+<names variable="editor" delimiter=", " prefix=" " suffix=".">
+<names variable="editor" delimiter=", " prefix=" ">
+<names variable="editor" delimiter=", " prefix=" (" suffix=")">
+<names variable="editor" delimiter=", " prefix=" [" suffix="]">
+<names variable="editor" delimiter=", " prefix="(" suffix=")">
+<names variable="editor" delimiter=", " prefix="(Ed. by " suffix=")">
+<names variable="editor" delimiter=", " prefix="ed. by ">
+<names variable="editor" delimiter=", " suffix=" ">
+<names variable="editor" delimiter=", " suffix=" Eds.; ">
+<names variable="editor" delimiter=", " suffix=", ">
+<names variable="editor" delimiter=", " suffix=",">
+<names variable="editor" delimiter=", " suffix=". " prefix=", in ">
+<names variable="editor" delimiter=", " suffix=".">
+<names variable="editor" delimiter=", " suffix=": ">
+<names variable="editor" delimiter=", " suffix=":">
+<names variable="editor" delimiter=", " suffix="; ">
+<names variable="editor" delimiter=", ">
+<names variable="editor" delimiter=",">
+<names variable="editor" delimiter=". " prefix=", ">
+<names variable="editor" delimiter=". ">
+<names variable="editor" delimiter="." suffix=" ">
+<names variable="editor" delimiter="/" suffix=",">
+<names variable="editor" delimiter="/">
+<names variable="editor" delimiter=": ">
+<names variable="editor" delimiter="; " prefix=" (" suffix=")">
+<names variable="editor" delimiter="; ">
+<names variable="editor" font-style="italic" delimiter=", ">
+<names variable="editor" font-style="italic" delimiter="/">
+<names variable="editor" font-style="italic"/>
+<names variable="editor" font-style="italic">
+<names variable="editor" font-style="normal" font-variant="normal">
+<names variable="editor" font-style="normal" prefix="(" suffix=")">
+<names variable="editor" font-style="normal"/>
+<names variable="editor" font-variant="normal" delimiter=", ">
+<names variable="editor" font-variant="normal" delimiter="/" prefix="in: " suffix=" (Hrsg.): ">
+<names variable="editor" font-variant="normal"/>
+<names variable="editor" font-variant="normal">
+<names variable="editor" font-variant="small-caps"/>
+<names variable="editor" font-weight="bold">
+<names variable="editor" font-weight="normal"/>
+<names variable="editor" prefix="           |editors=">
+<names variable="editor" prefix=" " delimiter=", ">
+<names variable="editor" prefix=" " suffix="," delimiter=", ">
+<names variable="editor" prefix=" " suffix=".">
+<names variable="editor" prefix=" "/>
+<names variable="editor" prefix=" ">
+<names variable="editor" prefix=" (" suffix=")">
+<names variable="editor" prefix=" (" suffix=")," delimiter=", ">
+<names variable="editor" prefix=" In " suffix=": ">
+<names variable="editor" prefix=" In ">
+<names variable="editor" prefix=" In: " suffix=". ">
+<names variable="editor" prefix="(" suffix=") ">
+<names variable="editor" prefix="(" suffix=")" delimiter=", ">
+<names variable="editor" prefix="(" suffix=")"/>
+<names variable="editor" prefix="(" suffix=")">
+<names variable="editor" prefix="(" suffix="),">
+<names variable="editor" prefix="(ed. by " suffix="), ">
+<names variable="editor" prefix=", ">
+<names variable="editor" prefix="/ под ред. " delimiter=", " suffix=".">
+<names variable="editor" prefix="In ">
+<names variable="editor" prefix="In: " suffix=" (eds) ">
+<names variable="editor" prefix="In: " suffix=" (eds), ">
+<names variable="editor" prefix="In: " suffix=", editor. ">
+<names variable="editor" prefix="In: " suffix=". ">
+<names variable="editor" prefix="In: " suffix=".">
+<names variable="editor" prefix="In: ">
+<names variable="editor" prefix="Interview by "/>
+<names variable="editor" prefix="Interview with ">
+<names variable="editor" prefix="edited by "/>
+<names variable="editor" prefix="edited by ">
+<names variable="editor" prefix="interviewed by " suffix="for ">
+<names variable="editor" prefix="interviewed by "/>
+<names variable="editor" suffix=" ">
+<names variable="editor" suffix=" (dir.)">
+<names variable="editor" suffix=" (ed):">
+<names variable="editor" suffix=" (ed.)"/>
+<names variable="editor" suffix=" (ed.),"/>
+<names variable="editor" suffix=" (éd.), ">
+<names variable="editor" suffix=" ed."/>
+<names variable="editor" suffix=" ed.,">
+<names variable="editor" suffix="(ed)"/>
+<names variable="editor" suffix=", ">
+<names variable="editor" suffix=", ed">
+<names variable="editor" suffix=", editor(s). ">
+<names variable="editor" suffix=",">
+<names variable="editor" suffix=".  ">
+<names variable="editor" suffix=". ">
+<names variable="editor" suffix=". ed; ">
+<names variable="editor" suffix=".">
+<names variable="editor" suffix="/">
+<names variable="editor" suffix=": "/>
+<names variable="editor" suffix=":">
+<names variable="editor"/>
+<names variable="editor">
+<names variable="editorial-director"/>
+<names variable="editorial-director">
+<names variable="illustrator">
+<names variable="interviewer editor translator" delimiter=", ">
+<names variable="interviewer illustrator container-author"/>
+<names variable="interviewer" delimiter=", " prefix="interview by ">
+<names variable="interviewer" delimiter=", ">
+<names variable="interviewer" prefix=" " suffix=" ">
+<names variable="interviewer" prefix=" entretien réalisé par ">
+<names variable="interviewer" prefix=" interview with ">
+<names variable="interviewer" prefix="entr. ">
+<names variable="interviewer" suffix=" (interv.)">
+<names variable="interviewer" suffix=" (interv.).">
+<names variable="interviewer"/>
+<names variable="interviewer">
+<names variable="original-author editor collection-editor translator"/>
+<names variable="original-author">
+<names variable="recipient" delimiter=" ; ">
+<names variable="recipient" delimiter=", " prefix="to ">
+<names variable="recipient" delimiter=", ">
+<names variable="recipient" prefix=" with "/>
+<names variable="recipient" prefix="Email sent to " suffix=",">
+<names variable="recipient" prefix="Letter to ">
+<names variable="recipient" prefix="lettre à ">
+<names variable="recipient" prefix="to ">
+<names variable="recipient"/>
+<names variable="recipient">
+<names variable="reviewed-author" delimiter=", ">
+<names variable="reviewed-author" suffix=", ">
+<names variable="reviewed-author">
+<names variable="translator editor container-author" delimiter=", " prefix=" (" suffix=")">
+<names variable="translator editor" delimiter=", " prefix=" ">
+<names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
+<names variable="translator editor" delimiter=", ">
+<names variable="translator editor"/>
+<names variable="translator" delimiter=" ; ">
+<names variable="translator" delimiter=", " prefix=" ">
+<names variable="translator" delimiter=", " prefix=" (" suffix=")">
+<names variable="translator" delimiter=", " prefix="trans. by ">
+<names variable="translator" delimiter=", ">
+<names variable="translator" delimiter="," suffix=",">
+<names variable="translator" delimiter=". " prefix=". ">
+<names variable="translator" delimiter=". ">
+<names variable="translator" delimiter="; ">
+<names variable="translator" font-style="italic"/>
+<names variable="translator" font-style="italic">
+<names variable="translator" font-style="normal"/>
+<names variable="translator" font-variant="normal"/>
+<names variable="translator" font-variant="small-caps"/>
+<names variable="translator" font-weight="bold">
+<names variable="translator" font-weight="normal"/>
+<names variable="translator" font-weight="normal">
+<names variable="translator" prefix=" " suffix="."/>
+<names variable="translator" prefix=" "/>
+<names variable="translator" prefix=" ">
+<names variable="translator" prefix="(" suffix=")">
+<names variable="translator" suffix=" trans.,">
+<names variable="translator" suffix="(tr)"/>
+<names variable="translator" suffix=", ">
+<names variable="translator" suffix=".">
+<names variable="translator"/>
+<names variable="translator">


### PR DESCRIPTION
This implements more than initially planned. It was easier to actually implement a few children. A non-CSL `<name-list>` rendering element has been introduced to facilitate the implementation of the CSL spec for `<names>`.